### PR TITLE
Fix retry loop for dylanaraps/bum#12

### DIFF
--- a/bum/__main__.py
+++ b/bum/__main__.py
@@ -9,6 +9,7 @@ Created by Dylan Araps
 """
 import argparse
 import pathlib
+import sys
 
 from . import display
 from . import song
@@ -52,7 +53,7 @@ def process_args(args):
     """Process the arguments."""
     if args.version:
         print(f"bum {__version__}")
-        exit(0)
+        sys.exit(0)
 
 
 def main():

--- a/bum/brainz.py
+++ b/bum/brainz.py
@@ -1,6 +1,7 @@
 """
 Musicbrainz related functions.
 """
+import time
 import musicbrainzngs as mus
 
 from .__init__ import __version__
@@ -13,7 +14,7 @@ def init():
                       "https://github.com/dylanaraps/bum")
 
 
-def get_cover(song, size=250):
+def get_cover(song, size=250, retry_delay=5, retries=5):
     """Download the cover art."""
     try:
         data = mus.search_releases(artist=song["artist"],
@@ -25,7 +26,11 @@ def get_cover(song, size=250):
         return mus.get_release_group_image_front(release_id, size=size)
 
     except mus.NetworkError:
-        get_cover(song, size)
+        if retries == 0:
+            raise mus.NetworkError("Failure connecting to MusicBrainz.org")
+        print(f"warning: Retrying download. {retries} retries left!")
+        time.sleep(retry_delay)
+        get_cover(song, size, retries=retries - 1)
 
     except mus.ResponseError:
         print("error: Couldn't find album art for",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 """bum - setup.py"""
 import setuptools
+import sys
 
 try:
     import bum
 except (ImportError, SyntaxError):
     print("error: bum requires Python 3.6 or greater.")
-    quit(1)
+    sys.exit(1)
 
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """bum - setup.py"""
-import setuptools
 import sys
+import setuptools
 
 try:
     import bum


### PR DESCRIPTION
Avoid a permenant retry-loop in cases where connectivity to musicbrainz.org fails. Tested using an `/etc/hosts` redirect to 127.0.0.1.

Hopefully fixes https://github.com/dylanaraps/bum/issues/12