### PR TITLE
Fix cache dir parsing for dylanaraps/bum#10

### DIFF
--- a/bum/__main__.py
+++ b/bum/__main__.py
@@ -29,7 +29,8 @@ def get_args():
 
     arg.add_argument("--cache_dir", metavar="\"/path/to/dir\"",
                      help="Where to store the downloaded cover art.",
-                     default=pathlib.Path.home() / ".cache/bum")
+                     default=pathlib.Path.home() / ".cache/bum",
+                     type=pathlib.Path)
 
     arg.add_argument("--version", action="store_true",
                      help="Print \"bum\" version.")


### PR DESCRIPTION
Implements a refined version of the fix suggested by @lasers in #10 - using `pathlib.Path` as the type directly.