### PR TITLE
Add default album art for dylanaraps/bum#11

### DIFF
--- a/bum/song.py
+++ b/bum/song.py
@@ -28,6 +28,7 @@ def get_art(cache_dir, size, client):
 
     if len(song) < 2:
         print("album: Nothing currently playing.")
+        util.bytes_to_file(util.default_album_art(), cache_dir / "current.jpg")
         return
 
     file_name = f"{song['artist']}_{song['album']}_{size}.jpg".replace("/", "")
@@ -43,8 +44,10 @@ def get_art(cache_dir, size, client):
         brainz.init()
         album_art = brainz.get_cover(song, size)
 
-        if album_art:
-            util.bytes_to_file(album_art, cache_dir / file_name)
-            util.bytes_to_file(album_art, cache_dir / "current.jpg")
+        if not album_art:
+            album_art = util.default_album_art()
 
-            print(f"album: Swapped art to {song['artist']}, {song['album']}.")
+        util.bytes_to_file(album_art, cache_dir / file_name)
+        util.bytes_to_file(album_art, cache_dir / "current.jpg")
+
+        print(f"album: Swapped art to {song['artist']}, {song['album']}.")

--- a/bum/util.py
+++ b/bum/util.py
@@ -2,6 +2,7 @@
 Util functions.
 """
 import pathlib
+import base64
 
 
 def bytes_to_file(input_data, output_file):
@@ -10,3 +11,22 @@ def bytes_to_file(input_data, output_file):
 
     with open(output_file, "wb") as file:
         file.write(input_data)
+
+
+def default_album_art():
+    return base64.b64decode("""
+iVBORw0KGgoAAAANSUhEUgAAAOYAAADmAQMAAAD7pGv4AAAABGdBTUEAALGPC/xhBQAAAAFzUkdC
+AK7OHOkAAAAGUExURf///yIkJdTndBEAAAKFSURBVFjDpdmxbSMxEIVhGhdMxgpYhEKWxdDhZdfW
+VXA1sBAHlheCIGlnvuBE2IC1lLn8d8mZN4+tvdEu7JvoXW2gd7ded378bVH3/vr981O1OP69av24
+ddXGMe2qzdtvhdsAvG/3rnBbDXywlsBxH6DCrYHHfeIVbg28HkbIcUvg22wDuCVwPA2R41bA42nq
+OW4FvF7GyHAL4PtcA7gFcJwGyXBz4HGafIabA69klJbcrQM3BX6gTIAjHSa72QZuBjyLv8/fH8BN
+gJ/mGcBNgKMc6HyrDdwz8MSn128P4J6AX2YZwD19DA7VOY1BhEn8xUe39dhPLyWaXujTheBS6Vxm
+g0t0cnkvbo2tbZVsumjasA+XgqGgM4wMhqDJ8LUY+rbCZhpUoykg3y8GQ31nmhhMMZPpaTG1baXF
+ImlGU8K9XQ6m8k4ZMCghJuXHonTZkj2lKIomQXV0BKVap8wblIiT8nJRmm7JWojeaBLM166gFO+U
+8YMlgAqECdwf4I3eDtwrMHCvwH9U8Hz8Yz30xd7PN3q//n9WJvLT8JP0W/Ab9NvnyvGq84r1avdO
+8S7zDvXuZmRwVHFEcjRzJHQUdQR29Gbkd9ZwxnG2cqZzlnSGdXZmZrcqsKKwGrGSsQqygrL6onKz
+6rNitNq0UrXKtUK2uqYyt6p3ReBqwpWIqxhXQK6eWHm5anPF52rRlaarVFe4ro5ZWbsqd0VvN8BO
+gl0IOxh2P+ic2HWxY2O3x06RXSY7VHa36IzZVbMjZzfPTqBdRDuQi8lrK/HZNbXjarfWTq9dYjvM
+i+JkS9jYFbejbjfeTr5PAXyCsCg+t4SrTz18YuLTFp/U+JTHJ0QX9F7aG+0bqTynufgX4tAAAAAA
+SUVORK5CYII=
+""")

--- a/bum/util.py
+++ b/bum/util.py
@@ -14,6 +14,7 @@ def bytes_to_file(input_data, output_file):
 
 
 def default_album_art():
+    """Return default album art as bytes."""
     return base64.b64decode("""
 iVBORw0KGgoAAAANSUhEUgAAAOYAAADmAQMAAAD7pGv4AAAABGdBTUEAALGPC/xhBQAAAAFzUkdC
 AK7OHOkAAAAGUExURf///yIkJdTndBEAAAKFSURBVFjDpdmxbSMxEIVhGhdMxgpYhEKWxdDhZdfW


### PR DESCRIPTION
We looked into a couple of approaches for supplying default cover art. The simplest seems to be to leverage as much of the existing image handling/caching functionality as possible by supplying the save function with a string of bytes similar to what it would receive from the MusicBrainz API.

Thanks to @septolum for coming up with an image that scales nicely and compresses well. It's actually a 2-colour PNG, but most image handling libraries don't care if the filename/content type mismatch. (Works for us in PIL, too)