### PR TITLE
Added flag which allows the user to override the default cover image

### DIFF
--- a/bum/__main__.py
+++ b/bum/__main__.py
@@ -46,6 +46,8 @@ def get_args():
     arg.add_argument("--no_display",
                      action="store_true",
                      help="Only download album art, don't display.")
+    arg.add_argument("--default_cover",
+                     help="Use a custom image for the cover when artwork can't be found")
 
     return arg.parse_args()
 
@@ -68,7 +70,7 @@ def main():
     client = song.init(args.port, args.server)
 
     while True:
-        song.get_art(args.cache_dir, args.size, client)
+        song.get_art(args.cache_dir, args.size, args.default_cover, client)
         if not args.no_display:
             display.launch(disp, args.cache_dir / "current.jpg")
 

--- a/bum/__main__.py
+++ b/bum/__main__.py
@@ -47,7 +47,7 @@ def get_args():
                      action="store_true",
                      help="Only download album art, don't display.")
     arg.add_argument("--default_cover",
-                     help="Use a custom image for the cover when artwork can't be found")
+                     help="Use a custom image for the default cover.")
 
     return arg.parse_args()
 

--- a/bum/song.py
+++ b/bum/song.py
@@ -22,7 +22,7 @@ def init(port=6600, server="localhost"):
         os._exit(1)  # pylint: disable=W0212
 
 
-def get_art(cache_dir, size, client):
+def get_art(cache_dir, size, default_cover, client):
     """Get the album art."""
     song = client.currentsong()
 
@@ -44,10 +44,11 @@ def get_art(cache_dir, size, client):
         brainz.init()
         album_art = brainz.get_cover(song, size)
 
-        if not album_art:
+        if not album_art and default_cover:
+            shutil.copy(default_cover, cache_dir / "current.jpg")
+        elif not album_art and not default_cover:
             album_art = util.default_album_art()
-
-        util.bytes_to_file(album_art, cache_dir / file_name)
-        util.bytes_to_file(album_art, cache_dir / "current.jpg")
+            util.bytes_to_file(album_art, cache_dir / file_name)
+            util.bytes_to_file(album_art, cache_dir / "current.jpg")
 
         print(f"album: Swapped art to {song['artist']}, {song['album']}.")

--- a/bum/song.py
+++ b/bum/song.py
@@ -28,6 +28,10 @@ def get_art(cache_dir, size, default_cover, client):
 
     if len(song) < 2:
         print("album: Nothing currently playing.")
+        if default_cover:
+            shutil.copy(default_cover, cache_dir / "current.jpg")
+            return
+
         util.bytes_to_file(util.default_album_art(), cache_dir / "current.jpg")
         return
 


### PR DESCRIPTION
This PR allows the user to override the default image displayed when there's no cover art. In conky, I'm using a black pixel as the nocover.jpg image, which allows conky to make the artwork "transparent".

You can override the default cover like so:

```
bum --cache_dir ~/.covers --no_display --default_cover ~/.covers/nocover.jpg
```