### PR TITLE
add --no_server option to just download one cover and exit

### DIFF
--- a/bum/__main__.py
+++ b/bum/__main__.py
@@ -43,6 +43,9 @@ def get_args():
                      help="Use a remote server instead of localhost.",
                      default="localhost")
 
+    arg.add_argument("--no_server", action="store_true",
+                     help="Don't run as a server; just download one cover and exit.")
+
     arg.add_argument("--no_display",
                      action="store_true",
                      help="Only download album art, don't display.")
@@ -70,9 +73,12 @@ def main():
     client = song.init(args.port, args.server)
 
     while True:
-        song.get_art(args.cache_dir, args.size, args.default_cover, client)
+        got_cover = song.get_art(args.cache_dir, args.size, args.default_cover, client)
         if not args.no_display:
             display.launch(disp, args.cache_dir / "current.jpg")
+
+        if args.no_server:
+            exit(int(not got_cover))
 
         client.send_idle()
 

--- a/bum/song.py
+++ b/bum/song.py
@@ -30,10 +30,10 @@ def get_art(cache_dir, size, default_cover, client):
         print("album: Nothing currently playing.")
         if default_cover:
             shutil.copy(default_cover, cache_dir / "current.jpg")
-            return
+            return False
 
         util.bytes_to_file(util.default_album_art(), cache_dir / "current.jpg")
-        return
+        return False
 
     file_name = f"{song['artist']}_{song['album']}_{size}.jpg".replace("/", "")
     file_name = cache_dir / file_name
@@ -41,6 +41,7 @@ def get_art(cache_dir, size, default_cover, client):
     if file_name.is_file():
         shutil.copy(file_name, cache_dir / "current.jpg")
         print("album: Found cached art.")
+        return True
 
     else:
         print("album: Downloading album art...")
@@ -56,3 +57,8 @@ def get_art(cache_dir, size, default_cover, client):
             util.bytes_to_file(album_art, cache_dir / "current.jpg")
 
         print(f"album: Swapped art to {song['artist']}, {song['album']}.")
+
+    if album_art:
+        return True
+    else:
+        return False


### PR DESCRIPTION
After opening #21 I realized it probably wouldn't be that hard to add this feature myself.

As expected, this just adds a `--no_server` argument that will make bum exit after downloading one cover.

Additionally, in this mode, bum will exit with a status code of `1` if it fails to find a cover.